### PR TITLE
[CI verify draft] ci/add-e2e-tests flatten check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,29 @@ jobs:
             dist/
             docs/
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - run: npm ci
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+      - name: Run e2e tests
+        run: npm run e2e
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   gh-pages:
     name: 'Host with GitHub Pages'
     runs-on: ubuntu-latest
@@ -87,6 +110,7 @@ jobs:
       contents: read
     needs:
       - build
+      - e2e
       - act-test
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -113,7 +137,7 @@ jobs:
         run: npm publish --access=public --tag=next
 
   deploy:
-    needs: build
+    needs: [build, e2e]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { Geolonia } from '../src/embed';
-import { TEST_URL, waitForMapLoad } from './helper';
+import { TEST_URL, waitForMapLoad, waitForStyleLoad } from './helper';
 
 declare global {
   interface Window {
@@ -57,6 +57,7 @@ test.describe('1. 基本的な地図表示', () => {
   test('1.4 アトリビューションが表示されていること', async ({ page }) => {
     await page.goto(`${TEST_URL}/basic.html`);
     await waitForMapLoad(page);
+    await waitForStyleLoad(page);
 
     // CustomAttributionControl は Shadow DOM 内にアトリビューションを描画する
     const attributionText = await page.evaluate(() => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## Purpose
sanak fork 上で CI を回すための draft PR。green 確認後にクローズ予定。

## Changes
- 3 commits (file-per-commit):
  1. `ci: add e2e test job and wire it into publish/deploy`
  2. `chore(e2e): switch playwright reporter from html to list for CI`
  3. `test(e2e): wait for style load before checking attribution`

## Notes
master との累積 diff: 3 files / +28 / -3。merge は行わない。